### PR TITLE
refactor: move config from bin to library so that it can be shared with other bins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project are documented in this file.
 - ci-adopt toolkit and standardise changelog (pr [#95])
 - chore-add opentelemetry packages group(pr [#120])
 - ci-upgrade jerusdp/circleci-toolkit orb version from 0.24.1 to 1.0.0(pr [#129])
+- refactor-move config from bin to library so that it can be shared with other bins(pr [#130])
 
 ### Security
 
@@ -269,6 +270,7 @@ All notable changes to this project are documented in this file.
 [#127]: https://github.com/jerusdp/ghdash/pull/127
 [#128]: https://github.com/jerusdp/ghdash/pull/128
 [#129]: https://github.com/jerusdp/ghdash/pull/129
+[#130]: https://github.com/jerusdp/ghdash/pull/130
 [Unreleased]: https://github.com/jerusdp/ghdash/compare/0.1.7...HEAD
 [0.1.7]: https://github.com/jerusdp/ghdash/compare/0.1.6...0.1.7
 [0.1.6]: https://github.com/jerusdp/ghdash/compare/0.1.5...0.1.6

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1,10 +1,8 @@
 mod cli;
-mod config;
 
 use crate::cli::{Commands, GhDashCli};
-use crate::config::GhConfig;
 use clap::Parser;
-use ghdash::{get_logging, Dashboard, DockerConnection, Error};
+use ghdash::{get_logging, Dashboard, DockerConnection, Error, GhConfig};
 
 const APP_NAME: &str = clap::crate_name!();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ use std::ffi::OsString;
 
 use serde_derive::{Deserialize, Serialize};
 
+/// Configuration data for the application
 #[derive(Default, Debug, Serialize, Deserialize, Clone)]
 pub struct GhConfig {
     user: String,
@@ -19,15 +20,18 @@ pub struct GhConfig {
 }
 
 impl GhConfig {
+    /// Create a new GhConfig
     pub fn user(&self) -> String {
         self.user.clone()
     }
 
+    /// Set the user github user name
     pub fn set_user(&mut self, user: &str) -> &mut Self {
         self.user = user.to_string();
         self
     }
 
+    /// Try to read the user from the environment
     pub fn try_env_user(&mut self, prefix: &str) -> &mut Self {
         let key = OsString::from(format!("{prefix}_USER").to_uppercase());
 
@@ -38,15 +42,18 @@ impl GhConfig {
         self
     }
 
+    /// Get the personal access token
     pub fn token(&self) -> String {
         self.token.clone()
     }
 
+    /// Set the personal access token
     pub fn set_token(&mut self, token: &str) -> &mut Self {
         self.token = token.to_string();
         self
     }
 
+    /// Try to read the token from the environment
     pub fn try_env_token(&mut self, prefix: &str) -> &mut Self {
         let key = OsString::from(format!("{prefix}_TOKEN").to_uppercase());
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,10 +28,12 @@
 //! ```
 //!
 
+mod config;
 mod dashboard;
 mod error;
 mod log;
 
+pub use config::GhConfig;
 pub use dashboard::Dashboard;
 pub use dashboard::RepoScope;
 pub use error::Error;


### PR DESCRIPTION
* refactor(cli): move config.rs from cli to src root
* feat(config.rs): add comments to GhConfig methods
* feat(lib.rs): expose GhConfig in the root module
* fix(main.rs): adjust import paths after moving config.rs