### PR TITLE
refactor: move cli to library so that it can be shared with other bins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project are documented in this file.
 - chore-add opentelemetry packages group(pr [#120])
 - ci-upgrade jerusdp/circleci-toolkit orb version from 0.24.1 to 1.0.0(pr [#129])
 - refactor-move config from bin to library so that it can be shared with other bins(pr [#130])
+- refactor-move cli to library so that it can be shared with other bins(pr [#131])
 
 ### Security
 
@@ -271,6 +272,7 @@ All notable changes to this project are documented in this file.
 [#128]: https://github.com/jerusdp/ghdash/pull/128
 [#129]: https://github.com/jerusdp/ghdash/pull/129
 [#130]: https://github.com/jerusdp/ghdash/pull/130
+[#131]: https://github.com/jerusdp/ghdash/pull/131
 [Unreleased]: https://github.com/jerusdp/ghdash/compare/0.1.7...HEAD
 [0.1.7]: https://github.com/jerusdp/ghdash/compare/0.1.6...0.1.7
 [0.1.6]: https://github.com/jerusdp/ghdash/compare/0.1.5...0.1.6

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,33 +6,38 @@
 //! it will be created in the default storage location for the OS.
 //!
 
+use super::RepoScope;
 use clap::{Parser, Subcommand};
-use ghdash::RepoScope;
 
+/// Command line app
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct GhDashCli {
+    /// Logging level
     #[clap(flatten)]
-    pub(crate) logging: clap_verbosity_flag::Verbosity,
+    pub logging: clap_verbosity_flag::Verbosity,
     /// Force the calculation of the version number
     /// alternate configuration file
     #[arg(short, long)]
-    pub(crate) config: Option<String>,
+    pub config: Option<String>,
     /// github user name
     #[arg(short, long)]
-    pub(crate) user: Option<String>,
+    pub user: Option<String>,
     /// github personal access token
     #[arg(short, long)]
-    pub(crate) token: Option<String>,
+    pub token: Option<String>,
     /// scope for the repositories shown in the dashboard
     #[arg(value_enum, short, long)]
-    pub(crate) repositories: Option<RepoScope>,
+    pub repositories: Option<RepoScope>,
+    /// Subcommand
     #[command(subcommand)]
-    pub(crate) command: Option<Commands>,
+    pub command: Option<Commands>,
 }
 
+/// Subcommands
 #[derive(Debug, Subcommand)]
-pub(crate) enum Commands {
+pub enum Commands {
+    /// List repositories
     #[command(hide = true)]
     List,
 }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1,8 +1,6 @@
-mod cli;
-
-use crate::cli::{Commands, GhDashCli};
 use clap::Parser;
 use ghdash::{get_logging, Dashboard, DockerConnection, Error, GhConfig};
+use ghdash::{Commands, GhDashCli};
 
 const APP_NAME: &str = clap::crate_name!();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,11 +28,14 @@
 //! ```
 //!
 
+mod cli;
 mod config;
 mod dashboard;
 mod error;
 mod log;
 
+pub use cli::Commands;
+pub use cli::GhDashCli;
 pub use config::GhConfig;
 pub use dashboard::Dashboard;
 pub use dashboard::RepoScope;


### PR DESCRIPTION
* refactor(cli.rs): rename cli/cli.rs to cli.rs, update visibility of struct fields and enum
* refactor(main.rs): remove cli module import, update import paths for Commands and GhDashCli
* feat(lib.rs): add cli module, export Commands and GhDashCli