### PR TITLE
chore: update release.toml to reference PRLOG.md instead of CHANGELOG.md

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -51,6 +51,7 @@ All notable changes to this project are documented in this file.
 - 🔧 chore(config)-update renovate schedule(pr [#268])
 - 🔧 chore(config)-update renovate schedule(pr [#270])
 - chore-rename CHANGELOG.md to PRLOG.md(pr [#286])
+- chore-update release.toml to reference PRLOG.md instead of CHANGELOG.md(pr [#287])
 
 ### Fixed
 
@@ -574,6 +575,7 @@ All notable changes to this project are documented in this file.
 [#283]: https://github.com/jerusdp/ghdash/pull/283
 [#285]: https://github.com/jerusdp/ghdash/pull/285
 [#286]: https://github.com/jerusdp/ghdash/pull/286
+[#287]: https://github.com/jerusdp/ghdash/pull/287
 [Unreleased]: https://github.com/jerusdp/ghdash/compare/v0.1.7...HEAD
 [0.1.7]: https://github.com/jerusdp/ghdash/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/jerusdp/ghdash/compare/v0.1.5...v0.1.6

--- a/release.toml
+++ b/release.toml
@@ -10,7 +10,7 @@ pre-release-replacements = [
     # {file = "README.md", search = "ghdash 0.*", replace = "{{crate_name}} {{version}}"},
     { file = "src/lib.rs", search = "ghdash = .*", replace = "{{crate_name}} = \"{{version}}\"" },
     { file = "tests/cmd/version.trycmd", search = "ghdash 0.*", replace = "{{crate_name}} {{version}}" },
-    { file = "CHANGELOG.md", search = "## \\[Unreleased\\]", replace = "## [{{version}}] - {{date}}", exactly = 1 },
-    { file = "CHANGELOG.md", search = "\\[Unreleased\\]:", replace = "[{{version}}]:", exactly = 1 },
-    { file = "CHANGELOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
+    { file = "PRLOG.md", search = "## \\[Unreleased\\]", replace = "## [{{version}}] - {{date}}", exactly = 1 },
+    { file = "PRLOG.md", search = "\\[Unreleased\\]:", replace = "[{{version}}]:", exactly = 1 },
+    { file = "PRLOG.md", search = "\\.\\.\\.HEAD", replace = "...{{tag_name}}", exactly = 1 },
 ]


### PR DESCRIPTION
This PR updates the `release.toml` configuration file to reference `PRLOG.md` instead of `CHANGELOG.md`.

## Changes
- Updated all file references from `CHANGELOG.md` to `PRLOG.md` in `release.toml`
- No functional changes to the release process, only file name consistency

## Context
This change aligns with the recent standardization effort to use `PRLOG.md` (Pull Request Log) as the consistent naming convention for changelog files across all repositories. The release automation tooling now properly references the renamed changelog file.

## Files Modified
- `release.toml` - Updated file references in release configuration