### PR TITLE
feat: add release-hook.sh script for automated changelog generation

### DIFF
--- a/PRLOG.md
+++ b/PRLOG.md
@@ -10,6 +10,7 @@ All notable changes to this project are documented in this file.
 - add GitHub API integration with octocrate(pr [#128])
 - add AuthSource enum for authentication source and refactor(pr [#136])
 - add new_with_github_app function to create GitHub API client(pr [#138])
+- add release-hook.sh script for automated changelog generation(pr [#288])
 
 ### Changed
 
@@ -576,6 +577,7 @@ All notable changes to this project are documented in this file.
 [#285]: https://github.com/jerusdp/ghdash/pull/285
 [#286]: https://github.com/jerusdp/ghdash/pull/286
 [#287]: https://github.com/jerusdp/ghdash/pull/287
+[#288]: https://github.com/jerusdp/ghdash/pull/288
 [Unreleased]: https://github.com/jerusdp/ghdash/compare/v0.1.7...HEAD
 [0.1.7]: https://github.com/jerusdp/ghdash/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/jerusdp/ghdash/compare/v0.1.5...v0.1.6

--- a/release-hook.sh
+++ b/release-hook.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Build Changelog
+gen-changelog generate --display-summaries --next-version "$SEMVER"


### PR DESCRIPTION
This PR adds a release-hook.sh script to enable automated changelog generation during the release process.

## Changes
- Added release-hook.sh script (executable)
- Script integrates with release tooling to generate changelog entries

## Purpose
This script will be automatically executed during the release process to generate changelog entries using the gen-changelog tool and update the PRLOG.md file with version-specific information.