### PR TITLE
fix: remove redundant packageRules from renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,16 +5,5 @@
   ],
   "extends": [
     "github>jerusdp/renovate-config:default.json"
-  ],
-  "packageRules": [
-    {
-      "matchPackageNames": ["jerusdp/circleci-toolkit"],
-      "enabled": false
-    },
-    {
-      "matchPackageNames": ["digital-prstv/circleci-toolkit"],
-      "enabled": true,
-      "sourceUrl": "https://github.com/jerus-org/circleci-toolkit"
-    }
   ]
 }


### PR DESCRIPTION
## Summary

- Removes `packageRules` from `renovate.json`

## Why

The shared config (`digital-prstv/renovate-config:default.json`) already handles all three `circleci-toolkit` variants:
- enables `digital-prstv/circleci-toolkit` with `sourceUrl → jerus-org/circleci-toolkit`
- enables `jerusdp/circleci-toolkit` (unused here, no PRs generated)
- enables `jerus-org/circleci-toolkit`

The repo-level overrides were redundant. Additionally, `enabled: false` for `jerusdp/circleci-toolkit` conflicted with the shared config's `enabled: true`, causing Renovate to open issue #348 ("Action Required: Fix Renovate Configuration").

## Test plan

- [ ] Merge — Renovate should close issue #348 on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)